### PR TITLE
Remove required effort + velocity for joint limit

### DIFF
--- a/urdfpy/urdf.py
+++ b/urdfpy/urdf.py
@@ -1443,8 +1443,8 @@ class JointLimit(URDFType):
     """
 
     _ATTRIBS = {
-        'effort': (float, True),
-        'velocity': (float, True),
+        'effort': (float, False),
+        'velocity': (float, False),
         'lower': (float, False),
         'upper': (float, False),
     }
@@ -1464,7 +1464,9 @@ class JointLimit(URDFType):
 
     @effort.setter
     def effort(self, value):
-        self._effort = float(value)
+        if value is not None:
+            value = float(value)
+        self._effort = value
 
     @property
     def velocity(self):
@@ -1474,7 +1476,9 @@ class JointLimit(URDFType):
 
     @velocity.setter
     def velocity(self, value):
-        self._velocity = float(value)
+        if value is not None:
+            value = float(value)
+        self._velocity = value
 
     @property
     def lower(self):


### PR DESCRIPTION
This PR removes that joints in the `.urdf` requires `effort` and `velocity` set. This is not a value usually set for articulated objects.